### PR TITLE
Fabric: Configuration Issue

### DIFF
--- a/Pock.xcodeproj/project.pbxproj
+++ b/Pock.xcodeproj/project.pbxproj
@@ -365,7 +365,7 @@
 			);
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
 			shellScript = "apiKey=$(sed -n '1p' < FabricEnv)\nsecretKey=$(sed -n '2p' < FabricEnv)\n\nINFO_PLIST=\"$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\"\n/usr/libexec/PlistBuddy -c \"Set :Fabric:APIKey string $apiKey\" \"$INFO_PLIST\"\n\n\"${PODS_ROOT}/Fabric/run\" $apiKey $secretKey\n";
 		};


### PR DESCRIPTION
There is a problem while building app, because of missing Fabric's apiKeys and secret key, which are used by script. I checked option 'Run script only when installing' in Build Phase in script section, so now Fabric's script won't be executed during building, but only on archiving app.