### PR TITLE
Remove period from "Quit Pock." option in menu bar app

### DIFF
--- a/Pock/AppDelegate.swift
+++ b/Pock/AppDelegate.swift
@@ -50,7 +50,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             menu.addItem(withTitle: "Preferences", action: #selector(openPreferences), keyEquivalent: "")
             // menu.addItem(withTitle: "Customize", action: #selector(openCustomization), keyEquivalent: "")
             menu.addItem(NSMenuItem.separator())
-            menu.addItem(withTitle: "Quit Pock.", action: #selector(NSApp.terminate(_:)), keyEquivalent: "")
+            menu.addItem(withTitle: "Quit Pock", action: #selector(NSApp.terminate(_:)), keyEquivalent: "")
             pockStatusbarIcon.menu = menu
         }
         


### PR DESCRIPTION
None of my other menu bar apps end their "Quit" options, or any other option, with a period. 

Apps menu screenshots: [Focus](https://user-images.githubusercontent.com/2449384/56275835-52254780-60b6-11e9-9365-21f93518e14e.png), [Tunnelblick](https://user-images.githubusercontent.com/2449384/56275836-52254780-60b6-11e9-85fe-63e653bfdf3e.png), [Fantastical](https://user-images.githubusercontent.com/2449384/56275837-52254780-60b6-11e9-8d47-9b349dcc10d7.png), [Google Backup & Sync](https://user-images.githubusercontent.com/2449384/56275967-90bb0200-60b6-11e9-87f9-1cb32d2de670.png)