### PR TITLE
Never show notification badges

### DIFF
--- a/Pock/Preferences/Preferences.swift
+++ b/Pock/Preferences/Preferences.swift
@@ -31,7 +31,7 @@ enum NotificationBadgeRefreshRateKeys: Double, Codable, CaseIterable {
     
     func toString() -> String {
         switch self {
-        case .never
+        case .never:
             return "Never"
         case .instantly:
             return "Instantly"

--- a/Pock/Preferences/Preferences.swift
+++ b/Pock/Preferences/Preferences.swift
@@ -20,6 +20,7 @@ extension NSNotification.Name {
 }
 
 enum NotificationBadgeRefreshRateKeys: Double, Codable, CaseIterable {
+    case never          = 0
     case instantly      = 0.25
     case oneSecond      = 1
     case fiveSeconds    = 5
@@ -30,6 +31,8 @@ enum NotificationBadgeRefreshRateKeys: Double, Codable, CaseIterable {
     
     func toString() -> String {
         switch self {
+        case .never
+            return "Never"
         case .instantly:
             return "Instantly"
         case .oneSecond:


### PR DESCRIPTION
Addressing this issue requesting [no notification badges](https://github.com/pigigaldi/Pock/issues/58)
Using the option never for the refresh rate will not show the notification badges.