### PR TITLE
Remove period from "Quit Pock."

### DIFF
--- a/Pock/AppDelegate.swift
+++ b/Pock/AppDelegate.swift
@@ -54,7 +54,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             menu.addItem(withTitle: "Preferences", action: #selector(openPreferences), keyEquivalent: "")
             // menu.addItem(withTitle: "Customize", action: #selector(openCustomization), keyEquivalent: "")
             menu.addItem(NSMenuItem.separator())
-            menu.addItem(withTitle: "Quit Pock.", action: #selector(NSApp.terminate(_:)), keyEquivalent: "")
+            menu.addItem(withTitle: "Quit Pock", action: #selector(NSApp.terminate(_:)), keyEquivalent: "")
             pockStatusbarIcon.menu = menu
         }
         


### PR DESCRIPTION
Mac apps do not commonly have periods in the quit entry of the menus.