### PR TITLE
Make Now Playing widged more usefull if nothing playing

### DIFF
--- a/Pock/Widgets/NowPlaying/NowPlayingItemView.swift
+++ b/Pock/Widgets/NowPlaying/NowPlayingItemView.swift
@@ -39,15 +39,15 @@ class NowPlayingItemView: PKDetailView {
         case "com.spotify.client", "com.apple.iTunes", "com.apple.Safari":
             break
         default:
-            appBundleIdentifier = "com.apple.iTunes"
+            appBundleIdentifier = "com.pigigaldi.pock"
         }
         
         let path = NSWorkspace.shared.absolutePathForApplication(withBundleIdentifier: appBundleIdentifier)
         
         DispatchQueue.main.async { [weak self] in
             self?.imageView.image          = DockRepository.getIcon(forBundleIdentifier: appBundleIdentifier, orPath: path)
-            self?.titleView.stringValue    = self?.nowPLayingItem?.title?.truncate(length: 20)  ?? "Pock"
-            self?.subtitleView.stringValue = self?.nowPLayingItem?.artist?.truncate(length: 20) ?? FileManager.default.displayName(atPath: path ?? "Unknown")
+            self?.titleView.stringValue    = self?.nowPLayingItem?.title?.truncate(length: 20)  ?? "No Playback"
+            self?.subtitleView.stringValue = self?.nowPLayingItem?.artist?.truncate(length: 20) ?? "Unknown"
             self?.updateForNowPlayingState()
         }
     }


### PR DESCRIPTION
If there is no playback, this is now also displayed in the Now Playing widget.
In addition, the Pock icon is displayed instead of the iTunes icon.
Finally, "unknown" is now always displayed when no artist is available (e.g. when there is no playback).