### PR TITLE
FIX - clock + battery in status widget stops updating

### DIFF
--- a/Pock/Widgets/Status/Items/SClockItem.swift
+++ b/Pock/Widgets/Status/Items/SClockItem.swift
@@ -42,7 +42,6 @@ class SClockItem: StatusItem {
     func didUnload() {
         refreshTimer?.invalidate()
         refreshTimer = nil
-        clockLabel = nil
     }
     
     var enabled: Bool{ return defaults[.shouldShowDateItem] }

--- a/Pock/Widgets/Status/Items/SClockItem.swift
+++ b/Pock/Widgets/Status/Items/SClockItem.swift
@@ -12,7 +12,7 @@ import Defaults
 class SClockItem: StatusItem {
     
     /// Core
-    private weak var refreshTimer: Timer?
+    private var refreshTimer: Timer?
     
     /// UI
     private var clockLabel: NSTextField!

--- a/Pock/Widgets/Status/Items/SPowerItem.swift
+++ b/Pock/Widgets/Status/Items/SPowerItem.swift
@@ -17,7 +17,7 @@ struct SPowerStatus {
 class SPowerItem: StatusItem {
     
     /// Core
-    private weak var refreshTimer: Timer?
+    private var refreshTimer: Timer?
     private var powerStatus: SPowerStatus = SPowerStatus(isCharging: false, currentValue: 0)
     private var shouldShowBatteryIcon: Bool {
         return defaults[.shouldShowBatteryIcon]


### PR DESCRIPTION
Removing the weak reference to prevent refreshTimer to get deallocated when computer goes to sleep.