### PR TITLE
Customize app expose settings

### DIFF
--- a/Pock.xcodeproj/project.pbxproj
+++ b/Pock.xcodeproj/project.pbxproj
@@ -621,7 +621,6 @@
 				TargetAttributes = {
 					348343D51F631B2E00CDA005 = {
 						CreatedOnToolsVersion = 8.3.3;
-						DevelopmentTeam = 788D9WZ9Z3;
 						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -1032,7 +1031,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 788D9WZ9Z3;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1060,7 +1059,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 788D9WZ9Z3;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Pock.xcworkspace/contents.xcworkspacedata
+++ b/Pock.xcworkspace/contents.xcworkspacedata
@@ -13,4 +13,7 @@
    <FileRef
       location = "group:Pods/Pods.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pock.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/Pock/Localisations/en.lproj/Localizable.strings
+++ b/Pock/Localisations/en.lproj/Localizable.strings
@@ -23,6 +23,8 @@
 "30 seconds" = "30 seconds";
 "1 minute" = "1 minute";
 "3 minutes" = "3 minutes";
+"More Than 1 Window" = "More Than 1 Window";
+"Always" = "Always";
 "Pock Options" = "Pock Options";
 "Preferences…" = "Preferences…";
 "Customize…" = "Customize…";

--- a/Pock/Localisations/it.lproj/Localizable.strings
+++ b/Pock/Localisations/it.lproj/Localizable.strings
@@ -23,6 +23,8 @@
 "30 seconds" = "30 secondi";
 "1 minute" = "1 minuto";
 "3 minutes" = "3 minuti";
+"More Than 1 Window" = "Più Di 1 Finestra";
+"Always" = "Sempre";
 "Pock Options" = "Menu di Pock";
 "Preferences…" = "Impostazioni…";
 "Customize…" = "Personalizza…";

--- a/Pock/Preferences/Panes/DockWidgetPreferencePane/Base.lproj/DockWidgetPreferencePane.xib
+++ b/Pock/Preferences/Panes/DockWidgetPreferencePane/Base.lproj/DockWidgetPreferencePane.xib
@@ -8,7 +8,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="DockWidgetPreferencePane" customModule="Pock" customModuleProvider="target">
             <connections>
-                <outlet property="alwaysOpenAppExposeCheckbox" destination="1bs-5V-WHc" id="gx6-yG-0lF"/>
+                <outlet property="appExposeSettingsPicker" destination="Zlx-Ef-hb0" id="sNk-bP-mdO"/>
                 <outlet property="hideFinderCheckbox" destination="caE-kj-Dca" id="oxs-PD-8sv"/>
                 <outlet property="hidePersistentItemsCheckbox" destination="UBz-m6-oWX" id="hWf-bv-jPv"/>
                 <outlet property="hideTrashCheckbox" destination="NIc-hs-c8t" id="FIq-Ge-h8t"/>
@@ -22,186 +22,226 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="340" height="271"/>
+            <rect key="frame" x="0.0" y="0.0" width="340" height="309"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gFt-UC-6tr">
-                    <rect key="frame" x="20" y="230" width="300" height="21"/>
+                <stackView distribution="fillEqually" orientation="vertical" alignment="leading" spacing="16" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VyA-ug-Nvm">
+                    <rect key="frame" x="20" y="16" width="300" height="277"/>
                     <subviews>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9xL-NG-zId">
-                            <rect key="frame" x="-2" y="4" width="194" height="17"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" enabled="NO" alignment="left" title="Notification badge refresh rate:" id="ICj-g3-VIO">
-                                <font key="font" metaFont="system"/>
-                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
-                        <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QqZ-9r-WHQ">
-                            <rect key="frame" x="196" y="-3" width="107" height="25"/>
-                            <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="fzh-TY-1IX" id="xk2-Vv-60X">
-                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="menu"/>
-                                <menu key="menu" id="grJ-RE-9Kq">
-                                    <items>
-                                        <menuItem title="Item 1" state="on" id="fzh-TY-1IX"/>
-                                        <menuItem title="Item 2" id="UnW-lx-nml"/>
-                                        <menuItem title="Item 3" id="Yra-28-ozo"/>
-                                    </items>
-                                </menu>
-                            </popUpButtonCell>
-                            <connections>
-                                <action selector="didSelectNotificationBadgeRefreshRate:" target="-2" id="Clu-Mj-qVG"/>
-                            </connections>
-                        </popUpButton>
-                    </subviews>
-                    <visibilityPriorities>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                    </visibilityPriorities>
-                    <customSpacing>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                    </customSpacing>
-                </stackView>
-                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="P9E-R2-fFj">
-                    <rect key="frame" x="20" y="211" width="300" height="5"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="1" id="ISK-gi-A7b"/>
-                    </constraints>
-                </box>
-                <stackView distribution="fillEqually" orientation="vertical" alignment="leading" spacing="13" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ltC-5f-Pcx">
-                    <rect key="frame" x="20" y="51" width="300" height="149"/>
-                    <subviews>
-                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="caE-kj-Dca">
-                            <rect key="frame" x="-2" y="133" width="92" height="18"/>
-                            <buttonCell key="cell" type="check" title="Hide Finder" bezelStyle="regularSquare" imagePosition="left" inset="2" id="PDB-GT-mUQ">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="didChangeHideFinderValueWithButton:" target="-2" id="eWF-7Y-Nax"/>
-                            </connections>
-                        </button>
-                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8qm-dH-CyJ">
-                            <rect key="frame" x="-2" y="106" width="167" height="18"/>
-                            <buttonCell key="cell" type="check" title="Show only running apps" bezelStyle="regularSquare" imagePosition="left" inset="2" id="qS6-8X-eGs">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="didChangeShowOnlyRunningAppsValueWithButton:" target="-2" id="MNp-r0-kb1"/>
-                            </connections>
-                        </button>
-                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UBz-m6-oWX">
-                            <rect key="frame" x="-2" y="79" width="152" height="18"/>
-                            <buttonCell key="cell" type="check" title="Hide Persistent Items" bezelStyle="regularSquare" imagePosition="left" inset="2" id="1qS-MJ-ICj">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="didChangeHidePersistentValueWithButton:" target="-2" id="e2B-ps-H3G"/>
-                            </connections>
-                        </button>
-                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NIc-hs-c8t" userLabel="Hide Trash Checkbox">
-                            <rect key="frame" x="18" y="52" width="88" height="18"/>
-                            <buttonCell key="cell" type="check" title="Hide Trash" bezelStyle="regularSquare" imagePosition="left" inset="2" id="vFP-uA-jfm">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="didChangeHideTrashValueWithButton:" target="-2" id="QO5-ng-fTk"/>
-                            </connections>
-                        </button>
-                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0Pj-5F-vBL">
-                            <rect key="frame" x="-2" y="25" width="271" height="18"/>
-                            <buttonCell key="cell" type="check" title="Opens Finder and directories inside Pock" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ckK-v4-yvT">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="didChangeOpenFinderInsidePockValueWithButton:" target="-2" id="RIh-W4-DlH"/>
-                            </connections>
-                        </button>
-                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1bs-5V-WHc">
-                            <rect key="frame" x="-2" y="-2" width="174" height="18"/>
-                            <buttonCell key="cell" type="check" title="Always open App Exposé" bezelStyle="regularSquare" imagePosition="left" inset="2" id="CHW-JM-8Bk">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="didChangeAlwaysOpenAppExposeValueWithButton:" target="-2" id="7wr-rj-PQ5"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="NIc-hs-c8t" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ltC-5f-Pcx" secondAttribute="leading" constant="20" id="OhL-lv-wIw"/>
-                    </constraints>
-                    <visibilityPriorities>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                    </visibilityPriorities>
-                    <customSpacing>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                    </customSpacing>
-                </stackView>
-                <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hrd-H5-paz">
-                    <rect key="frame" x="20" y="10" width="128" height="21"/>
-                    <subviews>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rdj-tL-R0L">
-                            <rect key="frame" x="-2" y="4" width="82" height="17"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" title="Item spacing" id="qJw-Vc-w0w">
-                                <font key="font" metaFont="system"/>
-                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
-                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VVh-2X-SdG">
-                            <rect key="frame" x="88" y="0.0" width="40" height="21"/>
+                        <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gFt-UC-6tr">
+                            <rect key="frame" x="0.0" y="247" width="300" height="30"/>
+                            <subviews>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="752" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9xL-NG-zId">
+                                    <rect key="frame" x="-2" y="13" width="224" height="17"/>
+                                    <textFieldCell key="cell" lineBreakMode="clipping" enabled="NO" alignment="left" title="Notification badge refresh rate:" id="ICj-g3-VIO">
+                                        <font key="font" metaFont="system"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                                <popUpButton horizontalHuggingPriority="252" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QqZ-9r-WHQ">
+                                    <rect key="frame" x="226" y="6" width="77" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="fzh-TY-1IX" id="xk2-Vv-60X">
+                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="menu"/>
+                                        <menu key="menu" id="grJ-RE-9Kq">
+                                            <items>
+                                                <menuItem title="Item 1" state="on" id="fzh-TY-1IX"/>
+                                                <menuItem title="Item 2" id="UnW-lx-nml"/>
+                                                <menuItem title="Item 3" id="Yra-28-ozo"/>
+                                            </items>
+                                        </menu>
+                                    </popUpButtonCell>
+                                    <connections>
+                                        <action selector="didSelectNotificationBadgeRefreshRate:" target="-2" id="Clu-Mj-qVG"/>
+                                    </connections>
+                                </popUpButton>
+                            </subviews>
+                            <visibilityPriorities>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                            </visibilityPriorities>
+                            <customSpacing>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                            </customSpacing>
+                        </stackView>
+                        <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xCL-Ye-myT">
+                            <rect key="frame" x="0.0" y="201" width="300" height="30"/>
+                            <subviews>
+                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="752" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jrg-4f-dhp">
+                                    <rect key="frame" x="-2" y="13" width="224" height="17"/>
+                                    <textFieldCell key="cell" lineBreakMode="clipping" enabled="NO" alignment="left" title="Open app exposé:" id="r6d-m5-Q8l">
+                                        <font key="font" metaFont="system"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                                <popUpButton horizontalHuggingPriority="252" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zlx-Ef-hb0">
+                                    <rect key="frame" x="226" y="6" width="77" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="pRj-TS-f3F" id="xoa-68-y75">
+                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="menu"/>
+                                        <menu key="menu" id="cpE-l7-RyX">
+                                            <items>
+                                                <menuItem title="Item 1" state="on" id="pRj-TS-f3F"/>
+                                                <menuItem title="Item 2" id="HIz-zB-e7Z"/>
+                                                <menuItem title="Item 3" id="2At-Ch-OCx"/>
+                                            </items>
+                                        </menu>
+                                    </popUpButtonCell>
+                                    <connections>
+                                        <action selector="didSelectAppExposeSettings:" target="-2" id="c3S-R3-mFG"/>
+                                    </connections>
+                                </popUpButton>
+                            </subviews>
+                            <visibilityPriorities>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                            </visibilityPriorities>
+                            <customSpacing>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                            </customSpacing>
+                        </stackView>
+                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="P9E-R2-fFj">
+                            <rect key="frame" x="0.0" y="182" width="300" height="5"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="40" id="jzh-nQ-SDe"/>
+                                <constraint firstAttribute="height" constant="1" id="ISK-gi-A7b"/>
                             </constraints>
-                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="border" placeholderString="8pt" drawsBackground="YES" id="aXg-gA-VhE">
-                                <font key="font" metaFont="system"/>
-                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
+                        </box>
+                        <stackView distribution="fillEqually" orientation="vertical" alignment="leading" spacing="13" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ltC-5f-Pcx">
+                            <rect key="frame" x="0.0" y="46" width="267" height="122"/>
+                            <subviews>
+                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="caE-kj-Dca">
+                                    <rect key="frame" x="-2" y="106" width="92" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Hide Finder" bezelStyle="regularSquare" imagePosition="left" inset="2" id="PDB-GT-mUQ">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="didChangeHideFinderValueWithButton:" target="-2" id="eWF-7Y-Nax"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8qm-dH-CyJ">
+                                    <rect key="frame" x="-2" y="79" width="167" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Show only running apps" bezelStyle="regularSquare" imagePosition="left" inset="2" id="qS6-8X-eGs">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="didChangeShowOnlyRunningAppsValueWithButton:" target="-2" id="MNp-r0-kb1"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UBz-m6-oWX">
+                                    <rect key="frame" x="-2" y="52" width="152" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Hide Persistent Items" bezelStyle="regularSquare" imagePosition="left" inset="2" id="1qS-MJ-ICj">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="didChangeHidePersistentValueWithButton:" target="-2" id="e2B-ps-H3G"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NIc-hs-c8t" userLabel="Hide Trash Checkbox">
+                                    <rect key="frame" x="18" y="25" width="88" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Hide Trash" bezelStyle="regularSquare" imagePosition="left" inset="2" id="vFP-uA-jfm">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="didChangeHideTrashValueWithButton:" target="-2" id="QO5-ng-fTk"/>
+                                    </connections>
+                                </button>
+                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0Pj-5F-vBL">
+                                    <rect key="frame" x="-2" y="-2" width="271" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Opens Finder and directories inside Pock" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ckK-v4-yvT">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <action selector="didChangeOpenFinderInsidePockValueWithButton:" target="-2" id="RIh-W4-DlH"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="NIc-hs-c8t" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ltC-5f-Pcx" secondAttribute="leading" constant="20" id="OhL-lv-wIw"/>
+                            </constraints>
+                            <visibilityPriorities>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                            </visibilityPriorities>
+                            <customSpacing>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                            </customSpacing>
+                        </stackView>
+                        <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hrd-H5-paz">
+                            <rect key="frame" x="0.0" y="0.0" width="128" height="30"/>
+                            <subviews>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rdj-tL-R0L">
+                                    <rect key="frame" x="-2" y="13" width="82" height="17"/>
+                                    <textFieldCell key="cell" lineBreakMode="clipping" title="Item spacing" id="qJw-Vc-w0w">
+                                        <font key="font" metaFont="system"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VVh-2X-SdG">
+                                    <rect key="frame" x="88" y="9" width="40" height="21"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="40" id="jzh-nQ-SDe"/>
+                                    </constraints>
+                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="border" placeholderString="8pt" drawsBackground="YES" id="aXg-gA-VhE">
+                                        <font key="font" metaFont="system"/>
+                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                            </subviews>
+                            <visibilityPriorities>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                            </visibilityPriorities>
+                            <customSpacing>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                            </customSpacing>
+                        </stackView>
                     </subviews>
+                    <constraints>
+                        <constraint firstItem="xCL-Ye-myT" firstAttribute="width" secondItem="VyA-ug-Nvm" secondAttribute="width" id="7vp-Aq-uYD"/>
+                        <constraint firstItem="gFt-UC-6tr" firstAttribute="width" secondItem="VyA-ug-Nvm" secondAttribute="width" id="zcz-D0-8i9"/>
+                    </constraints>
                     <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
                     </visibilityPriorities>
                     <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                     </customSpacing>
                 </stackView>
             </subviews>
             <constraints>
-                <constraint firstItem="P9E-R2-fFj" firstAttribute="leading" secondItem="gFt-UC-6tr" secondAttribute="leading" id="AZ0-tK-aoi"/>
-                <constraint firstItem="Hrd-H5-paz" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ltC-5f-Pcx" secondAttribute="bottom" constant="20" id="Fku-es-fPj"/>
-                <constraint firstItem="gFt-UC-6tr" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="O0J-T7-v5d"/>
-                <constraint firstItem="P9E-R2-fFj" firstAttribute="trailing" secondItem="gFt-UC-6tr" secondAttribute="trailing" id="VUQ-os-mhp"/>
-                <constraint firstItem="ltC-5f-Pcx" firstAttribute="top" secondItem="P9E-R2-fFj" secondAttribute="bottom" constant="13" id="VbG-Vg-bI6"/>
-                <constraint firstAttribute="bottom" secondItem="Hrd-H5-paz" secondAttribute="bottom" constant="10" id="eYS-hX-tMd"/>
-                <constraint firstItem="gFt-UC-6tr" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="20" id="geg-4J-Qgb"/>
-                <constraint firstItem="P9E-R2-fFj" firstAttribute="top" secondItem="gFt-UC-6tr" secondAttribute="bottom" constant="16" id="jdJ-i5-lpa"/>
-                <constraint firstAttribute="trailing" secondItem="gFt-UC-6tr" secondAttribute="trailing" constant="20" id="kNk-X7-f8m"/>
-                <constraint firstAttribute="trailing" secondItem="ltC-5f-Pcx" secondAttribute="trailing" constant="20" id="lu2-6r-xhc"/>
-                <constraint firstItem="Hrd-H5-paz" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="n3h-oG-Lw8"/>
-                <constraint firstItem="ltC-5f-Pcx" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="sec-Oo-6uV"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Hrd-H5-paz" secondAttribute="trailing" constant="20" id="vGZ-wv-kbJ"/>
+                <constraint firstAttribute="trailing" secondItem="VyA-ug-Nvm" secondAttribute="trailing" constant="20" id="6ko-2m-85p"/>
+                <constraint firstItem="VyA-ug-Nvm" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="16" id="B8J-uX-A5l"/>
+                <constraint firstItem="VyA-ug-Nvm" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="Cht-01-fWo"/>
+                <constraint firstAttribute="bottom" secondItem="VyA-ug-Nvm" secondAttribute="bottom" constant="16" id="Z2t-Mg-bPl"/>
             </constraints>
-            <point key="canvasLocation" x="69" y="139"/>
+            <point key="canvasLocation" x="69" y="206.5"/>
         </customView>
     </objects>
 </document>

--- a/Pock/Preferences/Panes/DockWidgetPreferencePane/DockWidgetPreferencePane.swift
+++ b/Pock/Preferences/Panes/DockWidgetPreferencePane/DockWidgetPreferencePane.swift
@@ -13,12 +13,12 @@ import Defaults
 class DockWidgetPreferencePane: NSViewController, PreferencePane {
     
     @IBOutlet weak var notificationBadgeRefreshRatePicker: NSPopUpButton!
+    @IBOutlet weak var appExposeSettingsPicker:            NSPopUpButton!
     @IBOutlet weak var hideFinderCheckbox:                 NSButton!
     @IBOutlet weak var showOnlyRunningApps:                NSButton!
     @IBOutlet weak var hideTrashCheckbox:                  NSButton!
     @IBOutlet weak var hidePersistentItemsCheckbox:        NSButton!
     @IBOutlet weak var openFinderInsidePockCheckbox:       NSButton!
-    @IBOutlet weak var alwaysOpenAppExposeCheckbox:        NSButton!
     @IBOutlet weak var itemSpacingTextField:               NSTextField!
     
     /// Preferenceable
@@ -42,7 +42,7 @@ class DockWidgetPreferencePane: NSViewController, PreferencePane {
     
     override func viewWillAppear() {
         super.viewWillAppear()
-        self.populatePopUpButton()
+        self.populatePopUpButtons()
         self.setupCheckboxes()
         self.setupItemSpacingTextField()
     }
@@ -52,10 +52,14 @@ class DockWidgetPreferencePane: NSViewController, PreferencePane {
         self.itemSpacingTextField.placeholderString = "8pt"
     }
     
-    private func populatePopUpButton() {
+    private func populatePopUpButtons() {
         self.notificationBadgeRefreshRatePicker.removeAllItems()
         self.notificationBadgeRefreshRatePicker.addItems(withTitles: NotificationBadgeRefreshRateKeys.allCases.map({ $0.toString() }))
         self.notificationBadgeRefreshRatePicker.selectItem(withTitle: defaults[.notificationBadgeRefreshInterval].toString())
+
+        self.appExposeSettingsPicker.removeAllItems()
+        self.appExposeSettingsPicker.addItems(withTitles: AppExposeSettings.allCases.map { $0.title })
+        self.appExposeSettingsPicker.selectItem(withTitle: defaults[.appExposeSettings].title)
     }
     
     private func setupCheckboxes() {
@@ -64,13 +68,16 @@ class DockWidgetPreferencePane: NSViewController, PreferencePane {
         self.hideTrashCheckbox.state            = defaults[.hideTrash]            ? .on : .off
         self.hidePersistentItemsCheckbox.state  = defaults[.hidePersistentItems]  ? .on : .off
         self.openFinderInsidePockCheckbox.state = defaults[.openFinderInsidePock] ? .on : .off
-        self.alwaysOpenAppExposeCheckbox.state  = defaults[.alwaysOpenAppExpose]  ? .on : .off
         self.hideTrashCheckbox.isEnabled        = !defaults[.hidePersistentItems]
     }
-    
+
     @IBAction private func didSelectNotificationBadgeRefreshRate(_: NSButton) {
         defaults[.notificationBadgeRefreshInterval] = NotificationBadgeRefreshRateKeys.allCases[self.notificationBadgeRefreshRatePicker.indexOfSelectedItem]
         NSWorkspace.shared.notificationCenter.post(name: .didChangeNotificationBadgeRefreshRate, object: nil)
+    }
+
+    @IBAction func didSelectAppExposeSettings(_: NSButton) {
+        defaults[.appExposeSettings] = AppExposeSettings.allCases[self.appExposeSettingsPicker.indexOfSelectedItem]
     }
     
     @IBAction private func didChangeHideFinderValue(button: NSButton) {
@@ -97,11 +104,6 @@ class DockWidgetPreferencePane: NSViewController, PreferencePane {
     @IBAction private func didChangeOpenFinderInsidePockValue(button: NSButton) {
         defaults[.openFinderInsidePock] = button.state == .on
     }
-    
-    @IBAction private func didChangeAlwaysOpenAppExposeValue(button: NSButton) {
-        defaults[.alwaysOpenAppExpose] = button.state == .on
-    }
-    
 }
 
 extension DockWidgetPreferencePane: NSTextFieldDelegate {

--- a/Pock/Preferences/Panes/DockWidgetPreferencePane/it.lproj/DockWidgetPreferencePane.strings
+++ b/Pock/Preferences/Panes/DockWidgetPreferencePane/it.lproj/DockWidgetPreferencePane.strings
@@ -32,5 +32,5 @@
 /* Class = "NSButtonCell"; title = "Hide Trash"; ObjectID = "vFP-uA-jfm"; */
 "vFP-uA-jfm.title" = "Nascondi Cestino";
 
-/* Class = "NSButtonCell"; title = "Always open App Exposé"; ObjectID = "CHW-JM-8Bk"; */
-"CHW-JM-8Bk.title" = "Apri sempre in App Exposé";
+/* Class = "NSTextFieldCell"; title = "Open app exposé:"; ObjectID = "r6d-m5-Q8l"; */
+"r6d-m5-Q8l.title" = "Apri app exposé:";

--- a/Pock/Preferences/Preferences.swift
+++ b/Pock/Preferences/Preferences.swift
@@ -62,19 +62,31 @@ enum NotificationBadgeRefreshRateKeys: Double, Codable, CaseIterable {
     }
 }
 
+enum AppExposeSettings : String, Codable, CaseIterable {
+    case never, ifNeeded, always
+
+    var title: String {
+        switch self {
+        case .never: return "Never".localized
+        case .ifNeeded: return "More Than 1 Window".localized
+        case .always: return "Always".localized
+        }
+    }
+}
+
 extension Defaults.Keys {
     static let launchAtLogin                    = Defaults.Key<Bool>("launchAtLogin",          default: false)
     static let hideControlStrip                 = Defaults.Key<Bool>("hideControlStrip",       default: false)
     static let enableAutomaticUpdates           = Defaults.Key<Bool>("enableAutomaticUpdates", default: false)
     /// Dock widget
     static let notificationBadgeRefreshInterval = Defaults.Key<NotificationBadgeRefreshRateKeys>("notificationBadgeRefreshInterval", default: .tenSeconds)
+    static let appExposeSettings                = Defaults.Key<AppExposeSettings>("appExposeSettings", default: .ifNeeded)
     static let itemSpacing                      = Defaults.Key<Int>("itemSpacing",             default: 8)
     static let hideFinder                       = Defaults.Key<Bool>("hideFinder",             default: false)
     static let showOnlyRunningApps              = Defaults.Key<Bool>("showOnlyRunningApps",    default: false)
     static let hideTrash                        = Defaults.Key<Bool>("hideTrash",              default: false)
     static let hidePersistentItems              = Defaults.Key<Bool>("hidePersistentItems",    default: false)
     static let openFinderInsidePock             = Defaults.Key<Bool>("openFinderInsidePock",   default: true)
-    static let alwaysOpenAppExpose              = Defaults.Key<Bool>("alwaysOpenAppExpose",    default: false)
     /// Status widget
     static let shouldShowWifiItem               = Defaults.Key<Bool>("shouldShowWifiItem",          default: true)
     static let shouldShowPowerItem              = Defaults.Key<Bool>("shouldShowPowerItem",         default: true)

--- a/Pock/Widgets/Dock/DockRepository.swift
+++ b/Pock/Widgets/Dock/DockRepository.swift
@@ -411,7 +411,8 @@ extension DockRepository {
             if !isProd { print("[Pock]: Can't load exposé items for: \(app.localizedName ?? "Unknown")") }
             return false
         }
-        guard defaults[.alwaysOpenAppExpose] || windows.count > 1 else {
+        let settings = defaults[.appExposeSettings]
+        guard settings == .always || (settings == .ifNeeded && windows.count > 1) else {
             if !isProd { print("[Pock]: Abort exposé. Reason: not needed for single element") }
             PockDockHelper.sharedInstance()?.activate(windows.first, in: app)
             return false
@@ -451,5 +452,4 @@ extension DockRepository {
             }
         })
     }
-    
 }


### PR DESCRIPTION


**Describe the Pull request**
This PR replaces the app exposé boolean settings that weren't ideal, with a dropdown menu that lets you choose between "always" show the app exposé, "never", or "if needed", which shows if there's more than 1 window.

By the way I also improved the autolayout a little bit. It was kinda messy imho 😅 

**Screenshots**

<img width="451" alt="image" src="https://user-images.githubusercontent.com/8419048/64378587-387da000-d057-11e9-8f30-08c131af827d.png">

<img width="339" alt="image" src="https://user-images.githubusercontent.com/8419048/64378622-4b907000-d057-11e9-83b3-641aea49a93c.png">

**Fixes**
https://github.com/pigigaldi/Pock/issues/206

**Pull request type**
Keep only the option that better matches your pull request.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


**Tested?**

I did test myself all the 3 behaviors. Manual/exploratory test, no unit tests.

*Test Configuration*:

<img width="256" alt="image" src="https://user-images.githubusercontent.com/8419048/64378731-84304980-d057-11e9-8ef0-38d0b1d5d4aa.png">

<img width="642" alt="image" src="https://user-images.githubusercontent.com/8419048/64378737-88f4fd80-d057-11e9-8111-9dcfe00e6f54.png">

**Checklist**
Use this list to keep track of your progress:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

No tests were written, as there're no related tests to similar parts of the app either 🤔 