### PR TITLE
Fixed clock not refreshing

### DIFF
--- a/Pock/Widgets/Status/Items/SClockItem.swift
+++ b/Pock/Widgets/Status/Items/SClockItem.swift
@@ -36,8 +36,8 @@ class SClockItem: StatusItem {
             clockLabel.isBezeled = false
             clockLabel.isEditable = false
             clockLabel.sizeToFit()
-            refreshTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
-                self?.reload()
+            refreshTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [ self] _ in
+                self.reload()
             })
         }
     }


### PR DESCRIPTION


---
name: Fixed clock not refreshing
about: Fixed the clock not refreshing after a few minutes
title: 'Fixed clock not refreshing'
labels: 'bug'
assignees: ''

---

**Fixes**
A comma-separated list of issues that can be closed with this PR.
• Fixed clock to refresh and not freeze after a couple of minutes


**Pull request type**
Keep only the option that better matches your pull request.

- [X] Bug fix (non-breaking change which fixes an issue)

**Tested?**
- Yes, on my Mac, see below.
- Usually clock freezes after 2-3 minutes, tested it for 10 minutes and it kept running.


*Test Configuration*:
* Hardware: MacBook Pro 2019 13'
* macOS Version: 10.14.6
* Xcode version: 11.0


**Checklist**
Use this list to keep track of your progress:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
