### PR TITLE
FIX Compilation and customization for dragging items out/in in Touchbar customization

### DIFF
--- a/Pock/Preferences/Panes/ControlCenterWidgetPreferencePane/ControlCenterWidgetPreferencePane.swift
+++ b/Pock/Preferences/Panes/ControlCenterWidgetPreferencePane/ControlCenterWidgetPreferencePane.swift
@@ -27,7 +27,7 @@ class ControlCenterWidgetPreferencePane: NSViewController, PreferencePane {
     @IBOutlet weak var showVolumeToggleItem:      NSButton!
     
     /// Preferenceable
-    var preferencePaneIdentifier: Identifier = Identifier.controler_center_widget
+    var preferencePaneIdentifier: Preferences.PaneIdentifier = Preferences.PaneIdentifier.controler_center_widget
     let preferencePaneTitle:      String     = "Control Center Widget".localized
     var toolbarItemIcon:          NSImage    = NSImage(named: "ControlCenterWidget")!
     

--- a/Pock/Preferences/Panes/DockWidgetPreferencePane/DockWidgetPreferencePane.swift
+++ b/Pock/Preferences/Panes/DockWidgetPreferencePane/DockWidgetPreferencePane.swift
@@ -22,7 +22,7 @@ class DockWidgetPreferencePane: NSViewController, PreferencePane {
     @IBOutlet weak var itemSpacingTextField:               NSTextField!
     
     /// Preferenceable
-    var preferencePaneIdentifier: Identifier = Identifier.dock_widget
+    var preferencePaneIdentifier: Preferences.PaneIdentifier = Preferences.PaneIdentifier.dock_widget
 
     let preferencePaneTitle:      String     = "Dock Widget".localized
     var toolbarItemIcon: NSImage {

--- a/Pock/Preferences/Panes/GeneralPreferencePane/GeneralPreferencePane.swift
+++ b/Pock/Preferences/Panes/GeneralPreferencePane/GeneralPreferencePane.swift
@@ -34,7 +34,7 @@ final class GeneralPreferencePane: NSViewController, PreferencePane {
     private static let appVersion = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String ?? "Unknown"
     
     /// Preferenceable
-    var preferencePaneIdentifier: Identifier = Identifier.general
+    var preferencePaneIdentifier: Preferences.PaneIdentifier = Preferences.PaneIdentifier.general
     let preferencePaneTitle:      String     = "General".localized
     let toolbarItemIcon:          NSImage    = NSImage(named: NSImage.preferencesGeneralName)!
     

--- a/Pock/Preferences/Panes/NowPlayingPreferencePane/NowPlayingPreferencePane.swift
+++ b/Pock/Preferences/Panes/NowPlayingPreferencePane/NowPlayingPreferencePane.swift
@@ -13,7 +13,7 @@ import Defaults
 class NowPlayingPreferencePane: NSViewController, PreferencePane {
 
     /// Preferenceable
-    var preferencePaneIdentifier: Identifier = Identifier.now_playing_widget
+    var preferencePaneIdentifier: Preferences.PaneIdentifier = Preferences.PaneIdentifier.now_playing_widget
     let preferencePaneTitle:      String     = "Now Playing Widget".localized
     var toolbarItemIcon:          NSImage {
         let id: String

--- a/Pock/Preferences/Panes/StatusWidgetPreferencePane/StatusWidgetPreferencePane.swift
+++ b/Pock/Preferences/Panes/StatusWidgetPreferencePane/StatusWidgetPreferencePane.swift
@@ -22,7 +22,7 @@ class StatusWidgetPreferencePane: NSViewController, NSTextFieldDelegate, Prefere
     @IBOutlet weak var timeFormatTextField:         NSTextField!
     
     /// Preferenceable
-    var preferencePaneIdentifier: Identifier = Identifier.status_widget
+    var preferencePaneIdentifier: Preferences.PaneIdentifier = Preferences.PaneIdentifier.status_widget
     let preferencePaneTitle:      String     = "Status Widget".localized
     var toolbarItemIcon:          NSImage {
         let path = NSWorkspace.shared.absolutePathForApplication(withBundleIdentifier: "com.apple.systempreferences")!

--- a/Pock/Preferences/Preferences.swift
+++ b/Pock/Preferences/Preferences.swift
@@ -12,12 +12,12 @@ import Defaults
 
 let isProd: Bool = true
 
-extension PreferencePane.Identifier {
-    static let general                 = Identifier("general")
-    static let dock_widget             = Identifier("dock_widget")
-    static let status_widget           = Identifier("status_widget")
-    static let controler_center_widget = Identifier("control_center_widget")
-    static let now_playing_widget      = Identifier("now_playing_widget")
+extension Preferences.PaneIdentifier {
+    static let general                 = Preferences.PaneIdentifier("general")
+    static let dock_widget             = Preferences.PaneIdentifier("dock_widget")
+    static let status_widget           = Preferences.PaneIdentifier("status_widget")
+    static let controler_center_widget = Preferences.PaneIdentifier("control_center_widget")
+    static let now_playing_widget      = Preferences.PaneIdentifier("now_playing_widget")
 }
 
 extension NSNotification.Name {

--- a/Pock/TouchBar/PKTouchBarController.swift
+++ b/Pock/TouchBar/PKTouchBarController.swift
@@ -101,6 +101,7 @@ extension PKTouchBarController {
     func openCustomization() {
         NSApp.touchBar = self.touchBar
         self.addCustomizationObservers()
+        NSApp.activate(ignoringOtherApps: true)
         self.perform(#selector(delayedOpenCustomization), with: nil, afterDelay: 0.3)
     }
     


### PR DESCRIPTION
---
name: FIX Compilation and customization for dragging items out/in in Touchbar customization
about: Create a pull request to contribute in making Pock amazing!
title: ''
labels: ''
assignees: @pigigaldi 

---

**Describe the Pull request**
Fixes the issue which causes to project not to compile. Also fixes issue which makes the touchbar not draggable when calling `NSApp.toggleTouchBarCustomizationPalette`

**Fixes**
A comma-separated list of issues that can be closed with this PR.
`[#295 ]`


**Pull request type**
Keep only the option that better matches your pull request.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected) :D :D :D 


**Tested?**
Yes, follow the pull request


*Test Configuration*:
* Hardware:      [MacBook Pro, 16" (Late 2019) (*required)
* macOS Version: [e.g. 10.15.5 (*required)]
* Xcode version: [e.g. 10.3 (*required)]


**Checklist**
Use this list to keep track of your progress:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works 
